### PR TITLE
Extract Variables don't Wrap Lines

### DIFF
--- a/docs/templates/applications.md
+++ b/docs/templates/applications.md
@@ -720,7 +720,7 @@ These weights are released under [the Apache License](https://github.com/tensorf
 
 
 ```python
-keras.applications.mobilenetv2.MobileNetV2(input_shape=None, alpha=1.0, depth_multiplier=1, include_top=True, weights='imagenet', input_tensor=None, pooling=None, classes=1000)
+keras.applications.mobilenet_v2.MobileNetV2(input_shape=None, alpha=1.0, depth_multiplier=1, include_top=True, weights='imagenet', input_tensor=None, pooling=None, classes=1000)
 ```
 
 MobileNetV2 model, with weights pre-trained on ImageNet.

--- a/examples/babi_memnn.py
+++ b/examples/babi_memnn.py
@@ -54,7 +54,6 @@ def parse_stories(lines, only_supporting=False):
         if '\t' in line:
             q, a, supporting = line.split('\t')
             q = tokenize(q)
-            substory = None
             if only_supporting:
                 # Only select the related substory
                 supporting = map(int, supporting.split())

--- a/examples/babi_rnn.py
+++ b/examples/babi_rnn.py
@@ -98,7 +98,6 @@ def parse_stories(lines, only_supporting=False):
         if '\t' in line:
             q, a, supporting = line.split('\t')
             q = tokenize(q)
-            substory = None
             if only_supporting:
                 # Only select the related substory
                 supporting = map(int, supporting.split())

--- a/examples/cifar10_cnn_capsule.py
+++ b/examples/cifar10_cnn_capsule.py
@@ -130,8 +130,6 @@ class Capsule(Layer):
         b = K.zeros_like(hat_inputs[:, :, :, 0])
         for i in range(self.routings):
             c = softmax(b, 1)
-            if K.backend() == 'theano':
-                o = K.sum(o, axis=1)
             o = self.activation(K.batch_dot(c, hat_inputs, [2, 2]))
             if i < self.routings - 1:
                 b = K.batch_dot(o, hat_inputs, [2, 3])

--- a/keras/backend/common.py
+++ b/keras/backend/common.py
@@ -111,7 +111,7 @@ def cast_to_floatx(x):
 
 
 def image_data_format():
-    """Returns the default image data format convention ('channels_first' or 'channels_last').
+    """Returns the default image data format convention.
 
     # Returns
         A string, either `'channels_first'` or `'channels_last'`

--- a/keras/backend/theano_backend.py
+++ b/keras/backend/theano_backend.py
@@ -1327,7 +1327,12 @@ def reverse(x, axes):
     """
     if isinstance(axes, int):
         axes = [axes]
-    slices = [py_slice(None, None, -1 if i in axes else None) for i in range(x.ndim)]
+    slices = []
+    for i in range(x.ndim)]:
+        if i in axes:
+            slices.add(py_slice(None, None, -1))
+        else:
+            slices.add(py_slice(None, None, None))
     return x[slices]
 
 
@@ -1529,8 +1534,10 @@ def rnn(step_function, inputs, initial_states,
             outputs = T.stack(*successive_outputs)
             states = []
             for i in range(len(successive_states[-1])):
-                states.append(T.stack(
-                    *[states_at_step[i] for states_at_step in successive_states]))
+                new_states = []
+                for states_at_step in successive_states:
+                    new_states.append(states_at_step[i])
+                states.append(T.stack(*new_states))
         else:
             # build an all-zero tensor of shape (samples, output_dim)
             initial_output = step_function(inputs[0], initial_states + constants)
@@ -2044,11 +2051,11 @@ def _postprocess_conv2d_output(conv_out, x,
                                strides, data_format):
     if padding == 'same':
         if kernel_shape[2] % 2 == 0:
-            conv_out = conv_out[
-                :, :, :(x.shape[2] + strides[0] - 1) // strides[0], :]
+            i = (x.shape[2] + strides[0] - 1) // strides[0]
+            conv_out = conv_out[:, :, :i, :]
         if kernel_shape[3] % 2 == 0:
-            conv_out = conv_out[
-                :, :, :, :(x.shape[3] + strides[1] - 1) // strides[1]]
+            i = (x.shape[3] + strides[1] - 1) // strides[1]
+            conv_out = conv_out[:, :, :, :i]
     if data_format == 'channels_last':
         conv_out = conv_out.dimshuffle((0, 2, 3, 1))
     return conv_out
@@ -2059,14 +2066,14 @@ def _postprocess_conv3d_output(conv_out, x,
                                strides, data_format):
     if padding == 'same':
         if kernel_shape[2] % 2 == 0:
-            conv_out = conv_out[
-                :, :, :(x.shape[2] + strides[0] - 1) // strides[0], :, :]
+            i = (x.shape[2] + strides[0] - 1) // strides[0]
+            conv_out = conv_out[:, :, :i, :, :]
         if kernel_shape[3] % 2 == 0:
-            conv_out = conv_out[
-                :, :, :, :(x.shape[3] + strides[1] - 1) // strides[1], :]
+            i = (x.shape[3] + strides[1] - 1) // strides[1]
+            conv_out = conv_out[:, :, :, :i, :]
         if kernel_shape[4] % 2 == 0:
-            conv_out = conv_out[
-                :, :, :, :, :(x.shape[4] + strides[2] - 1) // strides[2]]
+            i = (x.shape[4] + strides[2] - 1) // strides[2]
+            conv_out = conv_out[:, :, :, :, :i]
     if data_format == 'channels_last':
         conv_out = conv_out.dimshuffle((0, 2, 3, 4, 1))
     return conv_out

--- a/keras/callbacks.py
+++ b/keras/callbacks.py
@@ -885,8 +885,6 @@ class TensorBoard(Callback):
 
             self.saver = tf.train.Saver(list(embeddings_vars.values()))
 
-            embeddings_metadata = {}
-
             if not isinstance(self.embeddings_metadata, str):
                 embeddings_metadata = self.embeddings_metadata
             else:

--- a/keras/utils/data_utils.py
+++ b/keras/utils/data_utils.py
@@ -596,7 +596,7 @@ class OrderedEnqueuer(SequenceEnqueuer):
                 self.queue.task_done()
                 if inputs is not None:
                     yield inputs
-        except Exception as e:
+        except Exception:
             self.stop()
             six.reraise(*sys.exc_info())
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,9 +21,7 @@ pep8ignore=* E402 \
            * E731 \
            * W503 \
            keras/backend/cntk_backend.py E501 \
-           keras/backend/common.py E501 \
-           keras/backend/tensorflow_backend.py E501 \
-           tests/keras/backend/backend_test.py E501
+           keras/backend/tensorflow_backend.py E501
 
 # Enable line length testing with maximum line length of 85
 pep8maxlinelength = 85

--- a/tests/keras/backend/reference_operations.py
+++ b/tests/keras/backend/reference_operations.py
@@ -7,6 +7,7 @@ import numpy as np
 import scipy.signal as signal
 import scipy as sp
 from keras.backend import floatx
+from keras.utils.generic_utils import transpose_shape
 
 
 def normalize_conv(func):
@@ -431,6 +432,24 @@ def repeat(x, n):
     return y
 
 
+def temporal_padding(x, padding=(1, 1)):
+    return np.pad(x, [(0, 0), padding, (0, 0)], mode='constant')
+
+
+def spatial_2d_padding(x, padding=((1, 1), (1, 1)), data_format=None):
+    all_dims_padding = ((0, 0),) + padding + ((0, 0),)
+    all_dims_padding = transpose_shape(all_dims_padding, data_format,
+                                       spatial_axes=(1, 2))
+    return np.pad(x, all_dims_padding, mode='constant')
+
+
+def spatial_3d_padding(x, padding=((1, 1), (1, 1), (1, 1)), data_format=None):
+    all_dims_padding = ((0, 0),) + padding + ((0, 0),)
+    all_dims_padding = transpose_shape(all_dims_padding, data_format,
+                                       spatial_axes=(1, 2, 3))
+    return np.pad(x, all_dims_padding, mode='constant')
+
+
 def tile(x, n):
     return np.tile(x, n)
 
@@ -447,8 +466,28 @@ def batch_flatten(x):
     return np.reshape(x, (x.shape[0], -1))
 
 
+def gather(reference, indices):
+    return reference[indices]
+
+
 def eval(x):
     return x
+
+
+def get_value(x):
+    return x
+
+
+def count_params(x):
+    return x.size
+
+
+def int_shape(x):
+    return x.shape
+
+
+def get_variable_shape(x):
+    return int_shape(x)
 
 
 def dtype(x):
@@ -474,6 +513,44 @@ def dot(x, y):
     return np.dot(x, y)
 
 
+def batch_dot(x, y, axes=None):
+    if isinstance(axes, int):
+        axes = (axes, axes)
+    if axes is None:
+        # behaves like tf.batch_matmul as default
+        axes = [x.ndim - 1, y.ndim - 2]
+    if any([isinstance(a, (list, tuple)) for a in axes]):
+        raise ValueError('Multiple target dimensions are not supported. ' +
+                         'Expected: None, int, (int, int), ' +
+                         'Provided: ' + str(axes))
+    if x.ndim > y.ndim:
+        diff = x.ndim - y.ndim
+        y = np.reshape(y, np.concatenate([np.shape(y), [1] * diff], axis=0))
+    else:
+        diff = 0
+    if ndim(x) == 2 and ndim(y) == 2:
+        if axes[0] == axes[1]:
+            out = np.sum(np.multiply(x, y), axes[0])
+        else:
+            out = np.sum(np.multiply(np.transpose(x, [1, 0]), y), axes[1])
+    else:
+        out = np.tensordot(x, y, axes=axes)
+        for axis in [axes[0]]:
+            axis_list = np.arange(len(out.shape) - 1).tolist()
+            axis_list.insert(0, axis_list.pop(axis))
+            out = np.transpose(np.diagonal(out, axis1=0, axis2=axis),
+                               tuple(axis_list))
+    if diff:
+        if x.ndim > y.ndim:
+            idx = x.ndim + y.ndim - 3
+        else:
+            idx = x.ndim - 1
+        out = np.squeeze(out, tuple(range(idx, idx + diff)))
+    if ndim(out) == 1:
+        out = expand_dims(out, 1)
+    return out
+
+
 def transpose(x):
     return np.transpose(x)
 
@@ -491,6 +568,19 @@ def variable(value, dtype=None, name=None, constraint=None):
         raise TypeError("Constraint must be None when "
                         "using the NumPy backend.")
     return np.array(value, dtype)
+
+
+def dropout(x, level, noise_shape=None, seed=None):
+    if noise_shape is None:
+        noise_shape = x.shape
+    if learning_phase():
+        noise = np.random.choice([0, 1],
+                                 noise_shape,
+                                 replace=True,
+                                 p=[level, 1 - level])
+        return x * noise / (1 - level)
+    else:
+        return x
 
 
 def equal(x, y):

--- a/tests/keras/metrics_test.py
+++ b/tests/keras/metrics_test.py
@@ -28,20 +28,19 @@ all_sparse_metrics = [
 ]
 
 
-def test_metrics():
+@pytest.mark.parametrize('metric', all_metrics)
+def test_metrics(metric):
     y_a = K.variable(np.random.random((6, 7)))
     y_b = K.variable(np.random.random((6, 7)))
-    for metric in all_metrics:
-        output = metric(y_a, y_b)
-        print(metric.__name__)
-        assert K.eval(output).shape == (6,)
+    output = metric(y_a, y_b)
+    assert K.eval(output).shape == (6,)
 
 
-def test_sparse_metrics():
-    for metric in all_sparse_metrics:
-        y_a = K.variable(np.random.randint(0, 7, (6,)), dtype=K.floatx())
-        y_b = K.variable(np.random.random((6, 7)), dtype=K.floatx())
-        assert K.eval(metric(y_a, y_b)).shape == (6,)
+@pytest.mark.parametrize('metric', all_sparse_metrics)
+def test_sparse_metrics(metric):
+    y_a = K.variable(np.random.randint(0, 7, (6,)), dtype=K.floatx())
+    y_b = K.variable(np.random.random((6, 7)), dtype=K.floatx())
+    assert K.eval(metric(y_a, y_b)).shape == (6,)
 
 
 @pytest.mark.parametrize('shape', [(6,), (6, 3), (6, 3, 1)])


### PR DESCRIPTION
Update some of the refactorings to get line lengths under control by
extracting sub-expressions to their own variables ratther than
wrapping long lines. This should hopefully make things a little easier
to read.

### Summary

### Related Issues

### PR Overview

- [ ] This PR requires new unit tests [y/n] (make sure tests are included)
- [ ] This PR requires to update the documentation [y/n] (make sure the docs are up-to-date)
- [x] This PR is backwards compatible [y/n]
- [ ] This PR changes the current API [y/n] (all API changes need to be approved by fchollet)
